### PR TITLE
Register LarkNotifier and add cleanup logic

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,11 @@ notifier:
     url: "http://127.0.0.1:20403" # Your ntfy server URL (or use https://ntfy.sh)
     topic: "awa" # Topic name for notifications
 
+  # Lark (Feishu) notifier - sends messages to Lark via webhook
+  lark:
+    enabled: false # Set to true to enable Lark notifications
+    webhook_url: "https://open.feishu.cn/open-apis/bot/v2/hook/YOUR_WEBHOOK_TOKEN" # Your Lark webhook URL
+
 # Watchers configuration
 watchers:
   # IMAP Email Watcher

--- a/watchers/system_watcher.py
+++ b/watchers/system_watcher.py
@@ -55,7 +55,7 @@ class SystemMonitor:
         psutil.cpu_percent(interval=None)
         await asyncio.sleep(0.1)
 
-    def get_system_metrics(self) -> tuple[float, float, psutil._pslinux.svmem]:
+    def get_system_metrics(self) -> tuple[float, float, Any]:
         """
         Get current system metrics.
 
@@ -99,7 +99,7 @@ CPU usage has exceeded the configured threshold.
         self.last_cpu_alert_time = time.time()
 
     async def send_ram_alert(
-        self, ram_percent: float, memory: psutil._pslinux.svmem
+        self, ram_percent: float, memory: Any
     ) -> None:
         """
         Send RAM usage alert notification.


### PR DESCRIPTION
This commit addresses three code quality issues:

1. Register LarkNotifier in Notifier.__init__()
   - LarkNotifier was defined but never registered in the notifier system
   - Added initialization logic following the same pattern as console and ntfy notifiers

2. Add cleanup for LarkNotifier session
   - LarkNotifier creates an aiohttp.ClientSession but never closed it
   - Implemented LarkNotifier.close() method to properly close the session
   - Updated Notifier.close() to call close() on all notifiers that implement it

3. Fix platform-specific type hint in system_watcher.py
   - Changed psutil._pslinux.svmem to Any for cross-platform compatibility
   - The previous type hint would fail on non-Linux systems (Windows, macOS)

4. Add Lark configuration to config.example.yaml
   - Added example configuration for Lark notifier with webhook_url parameter
   - Helps users understand how to configure the Lark notifier

Files changed:
- notifier.py: Register LarkNotifier, add cleanup logic
- watchers/system_watcher.py: Fix type hints
- config.example.yaml: Add Lark configuration example